### PR TITLE
Feature : 회원가입 커스텀 페이지 구현완료

### DIFF
--- a/frontend/components/authButton.js
+++ b/frontend/components/authButton.js
@@ -1,9 +1,0 @@
-import { signIn } from "next-auth/react";
-
-const AuthButton = ({ classname, provider_id }) => {
-  return (
-    <button className={classname} onClick={() => signIn(provider_id)}></button>
-  );
-};
-
-export default AuthButton;

--- a/frontend/components/oAuth.js
+++ b/frontend/components/oAuth.js
@@ -12,13 +12,22 @@ const OAuth = () => {
           <div className="signup-box">
             <h1 className="signup-text">회원 가입</h1>
             <div className="signup-button">
-              <button className="signup-button-naver" onClick={signIn}>
+              <button
+                className="signup-button-naver"
+                onClick={() => signIn("naver")}
+              >
                 네이버 회원가입
               </button>
-              <button className="signup-button-kakao" onClick={signIn}>
+              <button
+                className="signup-button-kakao"
+                onClick={() => signIn("kakao")}
+              >
                 카카오톡 회원가입
               </button>
-              <button className="signup-button-google" onClick={signIn}>
+              <button
+                className="signup-button-google"
+                onClick={() => signIn("google")}
+              >
                 구글 회원가입
               </button>
             </div>
@@ -120,6 +129,6 @@ const OAuth = () => {
       `}</style>
     </>
   );
-}
+};
 
 export default OAuth;

--- a/frontend/pages/api/auth/[...nextauth].js
+++ b/frontend/pages/api/auth/[...nextauth].js
@@ -58,10 +58,6 @@ export default NextAuth({
   },
   secret: process.env.SECRET,
 
-  // pages: {
-  //   signIn: "/signup/oauth",
-  // },
-
   callbacks: {
     async jwt({ token, account }) {
       if (account) {

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -3,6 +3,5 @@ import { signIn, useSession } from "next-auth/react";
 
 export default function Home() {
   const { data: session, status } = useSession();
-  
   return <h1>{console.log(session)}</h1>;
 }


### PR DESCRIPTION
# 개요
회원가입 커스텀 페이지 구현 완료

# 작업사항
1. 원래는 우리가 만든 회원가입 페이지에서 각 oAuth 버튼을 누르면, nextauth에서 제공하는 기본 signIn 페이지로 넘어가고 그 페이지에서 또 사용자가 해당 oAuth 버튼을 눌러야지만 해당 oAuth 사이트로 넘어가 로그인이 진행됐었음
2. 그래서 우리가 만든 페이지의 각 oAuth 버튼에 provider를 직접 지정해줘서 중복되는 (nextauth 기본 제공 페이지) 페이지로 넘어가지 않게 해결함

# 변경로직
1. 각 oAuth 버튼에 onClick 이벤트에 그냥 signIn 대신에 signIn("google") 로 provider를 지정해주어 해결